### PR TITLE
Fixes for links getting broken by the refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-<<<<<<< HEAD
-_site/*
-=======
 _site/
->>>>>>> c22baf3586a6803fe1400ab40691b19cd8ad5855
+_posts/
+category/
+*~

--- a/_includes/css.html
+++ b/_includes/css.html
@@ -6,19 +6,19 @@
         <link rel="stylesheet" href="https://use.fontawesome.com/74dfc6cf47.css">
 
         <!-- Core BootStrap CSS -->
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
         <!-- Material Design CSS -->
-        <link rel="stylesheet" href="/{{ site.baseurl }}static/css/bootstrap-material-design.min.css">
+        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/bootstrap-material-design.min.css">
 
         <!-- syntax highlighting CSS -->
-        <link rel="stylesheet" href="/{{ site.baseurl }}static/css/syntax.css">
+        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/syntax.css">
 
         <!-- Custom CSS -->        
-        <link rel="stylesheet" href="/{{ site.baseurl }}static/css/thickbox.css">
-        <link rel="stylesheet" href="/{{ site.baseurl }}static/css/main.css">
-        <link rel="stylesheet" href="/{{ site.baseurl }}static/css/projects.css">
+        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/thickbox.css">
+        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/main.css">
+        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/projects.css">
 
         <script type="text/javascript">
           //loadingImage is relative to project dir
-          var tb_pathToImage = "/{{ site.baseurl }}static/img/loadingAnimation.gif";
+          var tb_pathToImage = "{{ site.baseurl }}/static/img/loadingAnimation.gif";
         </script>

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,8 +1,8 @@
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-<script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
-<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-<script src="/{{ site.baseurl }}static/js/thickbox-compressed.js"></script>
-<script src="/{{ site.baseurl }}static/js/material.min.js"></script>
-<script src="/{{ site.baseurl }}static/js/main.js"></script>
-<script src="/{{ site.baseurl }}static/js/projects.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+<script src="{{ site.baseurl }}/static/js/thickbox-compressed.js"></script>
+<script src="{{ site.baseurl }}/static/js/material.min.js"></script>
+<script src="{{ site.baseurl }}/static/js/main.js"></script>
+<script src="{{ site.baseurl }}/static/js/projects.js"></script>

--- a/_includes/main.html
+++ b/_includes/main.html
@@ -11,7 +11,7 @@
                 © 2016 Brad Matola <a href="#">Privacy link</a> - Powered by Jekyll.
               </footer>
               <div align="center">
-                <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+                <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
                 <ins class="adsbygoogle"
                      style="display:block"
                      data-ad-client="ca-pub-0776433630785969"

--- a/_includes/main.html
+++ b/_includes/main.html
@@ -8,7 +8,7 @@
           <div class="row">
             <div class="col-md-12 col-xs-12 footer">
               <footer>
-                © 2016 Brad Matola <a href="#">Privacy link</a> - Powered by Jekyll.
+                © 2016 Your Name <a href="#">Privacy link</a> - Powered by Jekyll.
               </footer>
               <div align="center">
                 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>


### PR DESCRIPTION
The refactor broke some baseurl use cases, and thus anything using it would not find any CSS or JavaScript files (including the demo site). This should fix it.

Also a few small additions to .gitignore and removal of site-specific names from the footer.