### PR TITLE
Projects: ability to select multiple tags at once

### DIFF
--- a/_includes/project_tags.html
+++ b/_includes/project_tags.html
@@ -1,6 +1,6 @@
 {% if site.enableTags ==  true %} 
 	<div id="tag-filter" class="col-md-12 col-xs-12 tag-group">
-		<span class="label label-primary tag-filter tag-cloud all">All</span>
+		<span class="label tag-filter tag-cloud all">Reset</span>
         {% assign tagarray = site.tagarray %}
         {% for project in site.data.projects %}
             {% for tag in project.tags %}

--- a/static/js/projects.js
+++ b/static/js/projects.js
@@ -1,20 +1,18 @@
 (function($){
 	$(document).ready(function(){
 		$(document).on('click','.tag-filter',function(){
-			$('span.tag-filter').removeClass("label-primary");
-			$(this).addClass("label-primary");
-
 			if( $(this).hasClass('all')){
+				$('span.tag-filter').removeClass("label-primary");
 				$('.project-item').showAll();
 			}else{
 				$('.project-item').filterTags( $(this).data('tag') );
 			}
+			$(this).addClass("label-primary");
 		});
 	});
 
 	$.fn.extend({
 	  filterTags: function(tagName) {
-	  	this.removeClass('not-show');
 	    return this.each(function() {
 	    	var itemTagArray = JSON.parse( $(this).attr('data-tags') );
 			if($.inArray(tagName, itemTagArray) === -1){


### PR DESCRIPTION
At the moment, the tag functionality in projects only allows one tag to be selected. This change allows multiple tags to be selected at once, which is very handy if there are a lot of projects listed.

With this change, when multiple tags are pressed, only those projects that include all the enabled tags are shown. The "All" button serves as a filter reset button, and is renamed as "Reset" for extra clarity.