### PR TITLE
Projects: fix for gaps with long project names

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -37,6 +37,8 @@ layout: default
     		</div>
     	</div>
         </div>
+    {% cycle '', '', '<div class="clearfix visible-lg-block visible-md-block"></div>' %}
+    {% cycle '', '<div class="clearfix visible-sm-block"></div>' %}
     {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
This change fixes the misalignment of project blocks (gaps), when their names take up varying numbers of lines in one row. For instance, right now if you have three projects that take up 3 lines, 2 lines and 1 line respectively, the next project will be alone in the next row, and the project after that will be on the third row.

The implemented fix is what's recommended by bootstrap developers: http://getbootstrap.com/css/#grid-responsive-resets