### PR TITLE
Fix for category url.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,7 +27,7 @@
                 <span class="categories">
                   &raquo; 
                   {% for category in page.categories %}
-                    <a href="category/{{ category }}">{{ category }}</a>
+                    <a href="{{ site.baseurl }}/category/{{ category }}">{{ category }}</a>
                     {% if forloop.last == false %}, {% endif %}
                   {% endfor %}
                 </span>


### PR DESCRIPTION
I think there is one problem here. The link to category is incorrect.
Click on the category name here and it redirects to a 404 page:  http://aboutashu.com/hcz-jekyll-blog/jekyll/2016/06/04/welcome-to-jekyll.html
I fixed the category url.